### PR TITLE
Update: "Alignment unit changed to byte to match cilium/ebpf Marshall method"

### DIFF
--- a/ebpf/xdp_redirect.c
+++ b/ebpf/xdp_redirect.c
@@ -43,6 +43,7 @@ struct pkt_meta {
     };
 };
 
+#pragma pack(push, 1)
 struct dest_info {
     __u32 saddr;
     __u32 daddr;
@@ -51,6 +52,7 @@ struct dest_info {
     __u8 dmac[6];
     __u16 ifindex;
 };
+#pragma pack(pop)
 
 struct bpf_elf_map SEC("maps") servers = {
     .type = BPF_MAP_TYPE_HASH,


### PR DESCRIPTION
Although it does not affect the operation of the current program, it is recommended to modify it here

In C, the sizeof of a structure is not always equal to the sum of the sizeof of each member.
But golang's cilium/ebpf is filled according to the length of the type.

If the structure is modified, cilium/ebpf will judge the length of the structure to be wrong

## Error

* [github.com/cilium/ebpf/marshalers.go](https://github.com/cilium/ebpf/blob/master/marshalers.go#L71)

```go
if len(buf) != length {
	return nil, fmt.Errorf("%T doesn't marshal to %d bytes", data, length)
}
```


## The corrected result is as follows

### C

* Sample 1

```c
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u8 ifindex;
};

// printf("%d", sizeof(struct dest_info); Output:  32
```

* Sample 2

```c
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u16 ifindex;
};

// printf("%d", sizeof(struct dest_info);  Output: 32
```

* Sample 3

```c
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u32 ifindex;
};

// printf("%d", sizeof(struct dest_info);   40
```

### Go

* Sample 1

```go
type RedirectMetaMap struct {
		SourceAddr uint32
		DestAddr   uint32
		Bytes      uint64
		Packages   uint64
		Mac        [6]uint8
		IfIndex    uint8
}

// The result of marshalBytes in cilium/ebpf Update is 31
```

* Sample 2

```go
type RedirectMetaMap struct {
		SourceAddr uint32
		DestAddr   uint32
		Bytes      uint64
		Packages   uint64
		Mac        [6]uint8
		IfIndex    uint16
}


// The result of marshalBytes in cilium/ebpf Update is // 32
```

* Sample 3

```go
type RedirectMetaMap struct {
		SourceAddr uint32
		DestAddr   uint32
		Bytes      uint64
		Packages   uint64
		Mac        [6]uint8
		IfIndex    uint32
}

// The result of marshalBytes in cilium/ebpf Update is // 34
```

## Specifies structure alignment

### C

* Sample 1

```c
#pragma pack(push, 1)
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u8 ifindex;
};
#pragma pack(pop)

// printf("%d", sizeof(struct dest_info); Output:  31
```

* Sample 2

```c
#pragma pack(push, 1)
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u16 ifindex;
};
#pragma pack(pop)

// printf("%d", sizeof(struct dest_info);  Output: 32
```

* Sample 3

```c
#pragma pack(push, 1)
struct dest_info {
    __u32 saddr;
    __u32 daddr;
    __u64 bytes;
    __u64 pkts;
    __u8 dmac[6];
    __u32 ifindex;
};
#pragma pack(pop)

// printf("%d", sizeof(struct dest_info);   34
```

